### PR TITLE
SCRUM-5: jwt clear

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -5,11 +5,15 @@ const crypto = require('crypto');
 const pool = require('../config/db');
 const jwtGuard = require('../middleware/jwt');
 
+
+// secret 키 설정 후 env에 정의 필요. 현재는 JWT_SECRET이 dev-secret-only-for-lab로 저장되어 있음.
 const DEV_SECRET = process.env.JWT_SECRET || 'dev-secret-only-for-lab';
+
+// jwt 발급 함수
 function signHS256(payload) {
   const h = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
   const p = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  const s = crypto.createHmac('sha256', DEV_SECRET).update(`${h}.${p}`).digest('base64url');
+  const s = crypto.createHmac('sha256', DEV_SECRET).update(`${h}.${p}`).digest('base64url');    // 헤더.페이로드 + secret key를 hs256으로 해시 후 base64
   return `${h}.${p}.${s}`;
 }
 
@@ -35,7 +39,7 @@ router.post('/login', async (req, res) => {
         id: user.id, username: user.username, role: user.role,
         exp: Math.floor(Date.now()/1000) + 10*60
       });
-      return res.json({ token, user });
+      return res.json({ token, user }); // 를 통해 클라에게 jwt 토큰 발급
     } catch (e) {
       conn.release();
       console.error(e);

--- a/frontend/public/assets/js/auth.js
+++ b/frontend/public/assets/js/auth.js
@@ -1,0 +1,99 @@
+// /assets/js/auth.js
+
+// === CSRF 토큰 ===
+function getCsrfToken() {
+  const m = document.querySelector('meta[name="csrf-token"]');
+  return m ? m.getAttribute('content') : null; // 나중에 서버가 실제 토큰으로 교체
+}
+
+// === JWT Bearer 토큰 (로컬 저장: 데모용; 실제는 HttpOnly 쿠키 권장) ===
+const LS_JWT = 'jwt_token';
+
+function setToken(token) {
+  localStorage.setItem(LS_JWT, token);
+}
+
+function getToken() {
+  return localStorage.getItem(LS_JWT);
+}
+
+function clearToken() {
+  localStorage.removeItem(LS_JWT);
+}
+
+// === 공통 fetch(JSON) ===
+async function postJSON(url, data) {
+  const headers = { 'Content-Type': 'application/json' };
+  const csrf = getCsrfToken();
+  if (csrf) headers['X-CSRF-Token'] = csrf;
+  const jwt = getToken();
+  if (jwt) headers['Authorization'] = `Bearer ${jwt}`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(data),
+    credentials: 'include', // 쿠키 기반 세션 병행 시
+  });
+
+  const text = await res.text();
+  let body = null;
+  try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+
+  if (!res.ok) {
+    const msg = body && body.error ? body.error : '요청 실패';
+    throw new Error(msg);
+  }
+  return body;
+}
+
+async function getJSON(url) {
+  const headers = {};
+  const csrf = getCsrfToken();
+  if (csrf) headers['X-CSRF-Token'] = csrf;
+  const jwt = getToken();
+  if (jwt) headers['Authorization'] = `Bearer ${jwt}`;
+
+  const res = await fetch(url, { headers, credentials: 'include' });
+  const text = await res.text();
+  let body = null;
+  try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+
+  if (!res.ok) {
+    const msg = body && body.error ? body.error : '요청 실패';
+    throw new Error(msg);
+  }
+  return body;
+}
+
+// 로그인 폼 바인딩
+function bindAuthForm(form, { endpoint, onSuccess, onError }) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fd = new FormData(form);
+    const payload = Object.fromEntries(fd.entries());
+
+    const btn = form.querySelector('button[type="submit"]');
+    const orig = btn.textContent;
+    btn.disabled = true; btn.textContent = '처리 중...';
+    try {
+      const session = await postJSON(endpoint, payload);
+      onSuccess && onSuccess(session);
+    } catch (err) {
+      onError && onError(err.message);
+    } finally {
+      btn.disabled = false; btn.textContent = orig;
+    }
+  });
+}
+
+// 현재 사용자 가져오기 (JWT 검증 통과 시)
+async function getMe() {
+  return getJSON('/api/auth/me');
+}
+
+window.setToken = setToken;
+window.getToken = getToken;
+window.clearToken = clearToken;
+window.getMe = getMe;
+window.bindAuthForm = bindAuthForm;


### PR DESCRIPTION
- jwt 토큰 구현 완료
- 프런트 딴의 auth.js 구현
1. 로컬 스토리지에 jwt 저장 및 관리하는 헬퍼
2. 로그인 폼 바인딩 (submit 이벤트 할당)
3. 사용자 정보 가져오기
4. csrf 토큰읽기 - 수정 필요